### PR TITLE
Fix missing cover API route

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -49,7 +49,9 @@ export async function PUT(request: Request, { params }: RouteParams) {
         description: data.description,
         publishedDate: data.publishedDate,
         publisher: data.publisher,
-        pageCount: data.pageCount,
+        pageCount: typeof data.pageCount === 'string'
+          ? parseInt(data.pageCount)
+          : data.pageCount ?? null,
       },
     });
     return NextResponse.json(book);

--- a/src/app/api/books/cover/route.ts
+++ b/src/app/api/books/cover/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getBookCoverUrlFromBook } from '@/utils/bookCsvUtils';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const title = searchParams.get('title') || searchParams.get('query') || '';
+  const author = searchParams.get('author') || undefined;
+  const isbn = searchParams.get('isbn') || undefined;
+
+  if (!title && !isbn) {
+    return NextResponse.json(
+      { error: 'Missing title or isbn parameter' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const coverUrl = await getBookCoverUrlFromBook({ title, author, isbn });
+    return NextResponse.json({ coverUrl });
+  } catch (error) {
+    console.error('Error fetching cover:', error);
+    return NextResponse.json(
+      { error: 'Error fetching cover' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add missing books/cover endpoint for fetching book cover images

## Testing
- `npm run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68414c4b564c832a82eae849f738e90f