### PR TITLE
Add progress types and improve CSV import workflow

### DIFF
--- a/src/components/CsvImportExport.tsx
+++ b/src/components/CsvImportExport.tsx
@@ -14,7 +14,7 @@ export function CsvImportExport({ onComplete }: CsvImportExportProps) {
   const [importing, setImporting] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [progress, setProgress] = useState<ImportProgress | ExportProgress | null>(null);
-  const { mutate } = useBooks();
+  const { refetch } = useBooks();
 
   const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -26,7 +26,7 @@ export function CsvImportExport({ onComplete }: CsvImportExportProps) {
         setProgress(progress);
       });
 
-      await mutate();
+      await refetch();
       
       toast.success(
         `Importazione completata: ${result.success} libri importati, ${result.errors} errori`

--- a/src/types/progress.ts
+++ b/src/types/progress.ts
@@ -1,0 +1,11 @@
+export interface ImportProgress {
+  status: string;
+  currentBook: number;
+  totalBooks: number;
+}
+
+export interface ExportProgress {
+  status: string;
+  currentBook: number;
+  totalBooks: number;
+}


### PR DESCRIPTION
## Summary
- define `ImportProgress` and `ExportProgress` interfaces
- refresh books after CSV import using `refetch`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run type-check` *(fails: cannot find module '@/components/ui/progress' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68414fb9c0c8832ab184b8ab9915d1e3